### PR TITLE
Backport PR 846

### DIFF
--- a/lib/puma/cli.rb
+++ b/lib/puma/cli.rb
@@ -25,6 +25,12 @@ module Puma
   # Handles invoke a Puma::Server in a command line style.
   #
   class CLI
+    KEYS_NOT_TO_PERSIST_IN_STATE = [
+      :logger, :lowlevel_error_handler,
+      :before_worker_shutdown, :before_worker_boot, :before_worker_fork,
+      :after_worker_boot, :before_fork, :on_restart
+    ]
+
     # Create a new CLI object using +argv+ as the command line
     # arguments.
     #
@@ -108,12 +114,7 @@ module Puma
       state = { 'pid' => Process.pid }
       cfg = @config.dup
 
-      [
-        :logger,
-        :before_worker_shutdown, :before_worker_boot, :before_worker_fork,
-        :after_worker_boot,
-        :on_restart, :lowlevel_error_handler
-      ].each { |k| cfg.options.delete(k) }
+      KEYS_NOT_TO_PERSIST_IN_STATE.each { |k| cfg.options.delete(k) }
       state['config'] = cfg
 
       require 'yaml'

--- a/test/config/state_file_testing_config.rb
+++ b/test/config/state_file_testing_config.rb
@@ -1,0 +1,14 @@
+pidfile "t3-pid"
+workers 3
+on_worker_boot do |index|
+  File.open("t3-worker-#{index}-pid", "w") { |f| f.puts Process.pid }
+end
+
+before_fork { 1 }
+on_worker_shutdown { 1 }
+on_worker_boot { 1 }
+on_worker_fork { 1 }
+on_restart { 1 }
+after_worker_boot { 1 }
+lowlevel_error_handler { 1 }
+

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -147,6 +147,21 @@ class TestCLI < Test::Unit::TestCase
     assert_equal url, data["config"].options[:control_url]
   end
 
+  def test_state_file_callback_filtering
+    cli = Puma::CLI.new [ "--config", "test/config/state_file_testing_config.rb", 
+                          "--state", @tmp_path ]
+    cli.send( :parse_options )
+    cli.write_state
+
+    data = nil
+    assert_nothing_raised do
+      data = YAML.load_file( @tmp_path )
+    end
+
+    keys_not_stripped = data.keys & Puma::CLI::KEYS_NOT_TO_PERSIST_IN_STATE
+    assert_empty keys_not_stripped
+  end
+
   def test_load_path
     cli = Puma::CLI.new ["--include", 'foo/bar']
     cli.send(:parse_options)


### PR DESCRIPTION
Backports PR 846.
Without this, we can't use `before_fork`, which we need in order to have Prometheus metrics in the listeners. This is because the Prometheus server needs to be started with `before_fork` to be able to have shared metrics across workers.